### PR TITLE
Added goal for injecting repositories into a project POM

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,20 @@ The plugin is not able to align dependencies when:
 * A dependency is inherited from a parent `pom.xml` which is not part of the target project structure.
 * A dependency version property is inherited from a parent `pom.xml` which is not part of the target project structure.
 
-### Goals
+## Goals
 
-* `upgrade`: Overrides dependencies versions in a project according to given Wildfly Channel file.
+* [`upgrade`](#upgrade)
+* [`inject-repositories`](#inject-repositories)
 
-### Configuration Parameters
+### `upgrade`
+
+Overrides dependencies versions in a project according to given Wildfly Channel file.
+
+Example:
+
+`mvn org.wildfly:wildfly-channel-maven-plugin:upgrade -DmanifestFile=manifest.yaml`
+
+#### Parameters
 
 * `channelFile`: Path to a Wildfly Channel file on a local filesystem.
 * `channelGAV`: Alternative to above, the channel file would be obtained from a maven repo.
@@ -50,6 +59,19 @@ The plugin is not able to align dependencies when:
   is to allow overriding transitive dependencies. If we wanted to have this, the final implementation should take 
   the real dependency tree into account, when figuring out which dependencies to inject.
 -->
+
+### `inject-repositories`
+
+Extracts repositories from given channel file, and adds these repositories to the project POM. The project build should
+then have access to all the repositories that the channel file references. 
+
+Example:
+
+`mvn org.wildfly:wildfly-channel-maven-plugin:inject-repositories -DfromChannelFile=channel.yaml`
+
+#### Parameters
+
+* `fromChannelFile`: Channel file to extract repositories from.
 
 ## Usage Examples
 

--- a/plugin/src/main/java/org/wildfly/channelplugin/InjectRepositoriesMojo.java
+++ b/plugin/src/main/java/org/wildfly/channelplugin/InjectRepositoriesMojo.java
@@ -1,0 +1,107 @@
+package org.wildfly.channelplugin;
+
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.RepositoryBase;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import org.commonjava.maven.ext.common.ManipulationException;
+import org.commonjava.maven.ext.common.model.Project;
+import org.commonjava.maven.ext.io.PomIO;
+import org.wildfly.channel.Channel;
+import org.wildfly.channel.ChannelMapper;
+import org.wildfly.channelplugin.manipulation.PomManipulator;
+
+import javax.inject.Inject;
+import javax.xml.stream.XMLStreamException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * This Mojo takes a channel file, extracts Maven repositories used by channels in the file, and injects those
+ * repositories into the project POM, so that Maven would use them to download dependencies from.
+ */
+@Mojo(name = "inject-repositories", requiresProject = true, requiresDirectInvocation = true)
+public class InjectRepositoriesMojo extends AbstractMojo {
+
+    /**
+     * Channel file path to extract repositories from.
+     */
+    @Parameter(required = true, property = "fromChannelFile")
+    String fromChannelFile;
+
+    @Inject
+    MavenSession mavenSession;
+
+    @Inject
+    MavenProject mavenProject;
+
+    @Inject
+    PomIO pomIO;
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        if (!mavenSession.getCurrentProject().isExecutionRoot()) {
+            // do not perform any work in submodules
+            return;
+        }
+
+        Path channelFilePath = Path.of(fromChannelFile);
+        if (!channelFilePath.isAbsolute()) {
+            channelFilePath = Path.of(mavenSession.getExecutionRootDirectory()).resolve(channelFilePath);
+        }
+
+        getLog().info("Reading channel file " + channelFilePath);
+        List<Channel> channels;
+        try (InputStream is = channelFilePath.toUri().toURL().openStream()) {
+            channels = ChannelMapper.fromString(new String(is.readAllBytes()));
+        } catch (IOException e) {
+            throw new MojoExecutionException("Can't read channel file", e);
+        }
+
+        try {
+            Project project = parseRootProject();
+            getLog().info("Root project: " + project.getArtifactId());
+            PomManipulator manipulator = new PomManipulator(project);
+
+            Set<String> existingRepositories = project.getModel().getRepositories().stream()
+                    .map(RepositoryBase::getUrl)
+                    .collect(Collectors.toSet());
+
+            channels.stream()
+                    .flatMap(c -> c.getRepositories().stream()).distinct()
+                    .forEach(r -> {
+                        if (!existingRepositories.contains(r.getUrl())) {
+                            try {
+                                getLog().info("Inserting repository " + r.getUrl());
+                                manipulator.injectRepository(r.getId(), r.getUrl());
+                            } catch (XMLStreamException e) {
+                                ChannelPluginLogger.LOGGER.errorf("Failed to inject repository: %s", e.getMessage());
+                            }
+                        } else {
+                            getLog().info(String.format("Repository with URL %s is already present.", r.getUrl()));
+                        }
+                    });
+
+            manipulator.writePom();
+        } catch (ManipulationException e) {
+            throw new MojoExecutionException("Can't parse project POM files", e);
+        }
+    }
+
+
+    /**
+     * Returns PME representation of current project module and its submodules.
+     */
+    private Project parseRootProject() throws ManipulationException {
+        return pomIO.parseProject(mavenProject.getModel().getPomFile()).stream().filter(Project::isExecutionRoot).findFirst().get();
+    }
+
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/SET-579

The goal would take a channel file path as a parameter and extract all repositories used by channels in this file. The repositories would then be injected as Maven repositories into the root project POM, so that Maven would use them to download project dependencies from.