### PR TITLE
Multiple input params

### DIFF
--- a/integration-tests/src/test/java/org/wildfly/channelplugin/it/VerifyDependenciesMojoIT.java
+++ b/integration-tests/src/test/java/org/wildfly/channelplugin/it/VerifyDependenciesMojoIT.java
@@ -22,7 +22,7 @@ public class VerifyDependenciesMojoIT {
     @MavenTest
     void unaligned_test_case(MavenExecutionResult result) throws Exception {
         assertThat(result).isFailure();
-        assertThat(result).out().warn().contains(
+        assertThat(result).out().error().contains(
                 "Dependency org.jboss.marshalling:jboss-marshalling:2.0.6.Final doesn't match expected version 2.0.9.Final-redhat-00001",
                 "Dependency commons-io:commons-io:2.10.0 doesn't match expected version 2.10.1.redhat-00001",
                 "Dependency io.undertow:undertow-core:2.2.5.Final doesn't match expected version 2.2.6.Final"

--- a/plugin/src/main/java/org/wildfly/channelplugin/VerifyDependenciesMojo.java
+++ b/plugin/src/main/java/org/wildfly/channelplugin/VerifyDependenciesMojo.java
@@ -123,7 +123,7 @@ public class VerifyDependenciesMojo extends AbstractChannelMojo {
             unalignedDependencies.forEach(pair -> {
                 ArtifactRef dep = pair.getLeft();
                 String v = pair.getRight();
-                getLog().warn(String.format("Dependency %s:%s:%s doesn't match expected version %s",
+                getLog().error(String.format("Dependency %s:%s:%s doesn't match expected version %s",
                         dep.getGroupId(), dep.getArtifactId(), dep.getVersionString(), v));
             });
             if (failBuild) {


### PR DESCRIPTION
Allow combine multiple channel/manifest input parameters, e.g. `-DmanivestFile` together with `-DmanifestGAV`.