### PR TITLE
Fix detection of transitive deps exclusions

### DIFF
--- a/core/src/main/java/org/wildfly/channeltools/util/ConversionUtils.java
+++ b/core/src/main/java/org/wildfly/channeltools/util/ConversionUtils.java
@@ -25,6 +25,10 @@ public final class ConversionUtils {
                 a.getClassifier());
     }
 
+    public static SimpleProjectRef toProjectRef(Dependency a) {
+        return new SimpleProjectRef(a.getGroupId(), a.getArtifactId());
+    }
+
     public static List<ProjectRef> toProjectRefs(List<Exclusion> exclusions) {
         if (exclusions == null) {
             return new ArrayList<>();

--- a/plugin/src/main/java/org/wildfly/channelplugin/UpgradeComponentsMojo.java
+++ b/plugin/src/main/java/org/wildfly/channelplugin/UpgradeComponentsMojo.java
@@ -46,6 +46,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.wildfly.channeltools.util.ConversionUtils.toArtifactRef;
+import static org.wildfly.channeltools.util.ConversionUtils.toProjectRef;
 import static org.wildfly.channeltools.util.ConversionUtils.toProjectRefs;
 
 /**
@@ -596,7 +597,7 @@ public class UpgradeComponentsMojo extends AbstractChannelMojo {
         for (MavenProject module: projects) {
 
             // Collect exclusions from the effective POM
-            Map<ArtifactRef, List<ProjectRef>> artifactExclusions = getDependencyExclusions(module);
+            Map<ProjectRef, List<ProjectRef>> artifactExclusions = getDependencyExclusions(module);
 
             ProjectBuildingRequest buildingRequest =
                     new DefaultProjectBuildingRequest(mavenSession.getProjectBuildingRequest());
@@ -632,7 +633,7 @@ public class UpgradeComponentsMojo extends AbstractChannelMojo {
                     return;
                 }
 
-                List<ProjectRef> exclusions = artifactExclusions.getOrDefault(artifact, Collections.emptyList());
+                List<ProjectRef> exclusions = artifactExclusions.getOrDefault(artifact.asProjectRef(), Collections.emptyList());
                 HashSet<ProjectRef> exclusionsSet = new HashSet<>(exclusions);
 
                 addOrUpdateArtifact(transitiveDependencies, artifact, exclusionsSet);
@@ -685,13 +686,14 @@ public class UpgradeComponentsMojo extends AbstractChannelMojo {
                 && nullableStringsEqual(r1.getClassifier(), r2.getClassifier());
     }
 
-    private static Map<ArtifactRef, List<ProjectRef>> getDependencyExclusions(MavenProject module) {
-        Map<ArtifactRef, List<ProjectRef>> artifactExclusions = new HashMap<>();
+    private static Map<ProjectRef, List<ProjectRef>> getDependencyExclusions(MavenProject module) {
+        Map<ProjectRef, List<ProjectRef>> artifactExclusions = new HashMap<>();
         List<Dependency> managedDependencies = Collections.emptyList();
         if (module.getModel().getDependencyManagement() != null) {
             managedDependencies = module.getModel().getDependencyManagement().getDependencies();
         }
-        managedDependencies.forEach(dep -> artifactExclusions.put(toArtifactRef(dep), toProjectRefs(dep.getExclusions())));
+        managedDependencies.forEach(dep -> artifactExclusions.put(toProjectRef(dep),
+                toProjectRefs(dep.getExclusions())));
         return artifactExclusions;
     }
 


### PR DESCRIPTION
We run into problem in cases where a dependency version is not declared in dependency management section:

https://github.com/wildfly/wildfly/pull/19805

Giving exception like:

```
Caused by: org.commonjava.maven.atlas.ident.ref.InvalidRefException: Version spec AND string cannot both be empty for 'com.fasterxml.jackson.jr:jackson-jr-objects'
    at org.commonjava.maven.atlas.ident.ref.SimpleProjectVersionRef.<init> (SimpleProjectVersionRef.java:63)
    at org.commonjava.maven.atlas.ident.ref.SimpleProjectVersionRef.<init> (SimpleProjectVersionRef.java:79)
    at org.commonjava.maven.atlas.ident.ref.SimpleArtifactRef.<init> (SimpleArtifactRef.java:69)
    at org.wildfly.channeltools.util.ConversionUtils.toArtifactRef (ConversionUtils.java:20)
    at org.wildfly.channelplugin.UpgradeComponentsMojo.lambda$getDependencyExclusions$9 (UpgradeComponentsMojo.java:694)
    at java.util.ArrayList.forEach (ArrayList.java:1511)
    at org.wildfly.channelplugin.UpgradeComponentsMojo.getDependencyExclusions (UpgradeComponentsMojo.java:694)
    at org.wildfly.channelplugin.UpgradeComponentsMojo.findTransitiveDependencies (UpgradeComponentsMojo.java:599)
    at org.wildfly.channelplugin.UpgradeComponentsMojo.injectTransitiveDependencies (UpgradeComponentsMojo.java:540)
```