### PR TITLE
Upgrade wildfly-channel to 1.2.3.Final / pre-emptive auth support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <maven.version>3.6.3</maven.version> <!-- Note that PME depends on 3.5.0 -->
         <maven-resolver.version>1.6.2</maven-resolver.version>
         <pme.version>4.7</pme.version>
-        <channel.version>1.2.1.Final</channel.version>
+        <channel.version>1.2.3.Final</channel.version>
         <jupiter.version>5.7.2</jupiter.version>
         <assertj.version>3.22.0</assertj.version>
         <itf.version>0.13.1</itf.version>


### PR DESCRIPTION
This is to add pre-emptive auth support when download metadata from authenticated URLs.